### PR TITLE
Change year to 2019 and to update automatically

### DIFF
--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -6,7 +6,7 @@
         <a class="p-button--neutral is-compact" href="https://www.ubuntu.com/contact-us"><small>Contact us</small></a>
       </li>
     </ul>
-    <p class="u-no-max-width">&copy; 2019 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+    <p class="u-no-max-width">&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
     <nav class="p-footer__nav" role="navigation">
       <ul class="p-footer__links">
         <li class="p-footer__item">


### PR DESCRIPTION
## Done

Change year in the footer to 2019

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Make sure the current year is displayed in the footer.


## Issue / Card

Fixes #358 

