### PR TITLE
Move from gevent to sync workers

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.wsgi --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn webapp.wsgi --bind $1 --worker-class sync --workers 5 --name talisker-`hostname`"
 
 if [ "${DJANGO_DEBUG}" = true ] || [ "${DJANGO_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ django-asset-server-url==0.1
 feedparser==5.2.1
 requests-cache==0.4.13
 python-dateutil==2.8.0
-talisker==0.14.2
-gunicorn[gevent]
+talisker[gunicorn]==0.14.2

--- a/webapp/wsgi.py
+++ b/webapp/wsgi.py
@@ -9,7 +9,10 @@ https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 import os
 
 # Modules
+import talisker.logs
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "webapp.settings")
 application = get_wsgi_application()
+
+talisker.logs.set_global_extra({"service": "canonical.com"})


### PR DESCRIPTION
## Done

* Move from gevent to sync workers
* Add service name in logs

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Make sure we get `service=canonical.com` inlogs

