### PR TITLE
Change template module with latest one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.versioned-static==1.0.2
 canonicalwebteam.get-feeds==0.2.4
 Django==1.11.20
 whitenoise==4.1.2
-django-template-finder-view==0.3
+canonicalwebteam.django_views==1.3.4
 django-json-redirects==0.3
 django-static-root-finder==0.3.1
 django-asset-server-url==0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ django-asset-server-url==0.1
 feedparser==5.2.1
 requests-cache==0.4.13
 python-dateutil==2.8.0
-talisker[gunicorn]==0.14.2
+talisker[gunicorn,prometheus,raven,django]==0.14.2

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -8,6 +8,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
+import logging.config
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -27,6 +28,9 @@ ALLOWED_HOSTS = ['*']
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+MIDDLEWARE = [
+    "talisker.django.middleware",
+]
 MIDDLEWARE_CLASSES = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
@@ -66,6 +70,7 @@ TEMPLATES = [
     },
 ]
 
+LOGGING_CONFIG = None
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -86,3 +91,5 @@ LOGGING = {
         }
     }
 }
+
+logging.config.dictConfig(LOGGING)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -3,7 +3,7 @@ Django views for www.canonical.com.
 """
 from django.conf import settings
 from django.views.generic.base import TemplateView
-from django_template_finder_view import TemplateFinder
+from canonicalwebteam.django_views import TemplateFinder
 from webapp.templatetags.raw_feeds import get_raw_json_feed
 from django.views.static import serve
 


### PR DESCRIPTION
## Done

* Update `django-template-finder-view` to `canonicalwebteam.django_views`
* Fixes the 500 on /index.html

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. http://0.0.0.0:8002/index.html
5. navigate on the site and make sure the pages still display well
