### PR TITLE
Add google recaptcha to forms

### DIFF
--- a/templates/partners/contact-us.html
+++ b/templates/partners/contact-us.html
@@ -3,7 +3,6 @@
 {% block title %}Contact Canonical | Partners{% endblock %}
 
 {% block content %}
-
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
@@ -391,10 +390,16 @@
               <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
               <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
             </li>
+
+            <li class="mktField">
+              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+            </li>
+
             <li>All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
             <li class="mktField">
               <button type="submit" class="mktoButton">Submit</button>
               <input type="hidden" name="formid" class="mktoField " value="1260">
+              <input type="hidden" name="formVid" class="mktoField " value="1260">
               <input type="hidden" name="lpId" class="mktoField " value="1558">
               <input type="hidden" name="subId" class="mktoField" value="30">
               <input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335">
@@ -435,5 +440,6 @@
     </div>
   </div>
 </section>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
 {% endblock content %}

--- a/templates/services/contact-us.html
+++ b/templates/services/contact-us.html
@@ -4,7 +4,6 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1qi9Tj8F6fxr1nGk3vs12qEMEXDSiFcVqKeFPqO9nh9U/edit{% endblock meta_copydoc %}
 
 {% block content %}
-
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
@@ -384,6 +383,11 @@
               <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox" />
               <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
             </li>
+
+            <li class="mktField">
+              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+            </li>
+
             <li>
               <p>
                 In submitting this form, I confirm that I have read and agree to <a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a>.
@@ -394,6 +398,7 @@
             </li>
           </ul>
           <input type="hidden" name="formid" class="mktoField" value="1240" />
+          <input type="hidden" name="formVid" class="mktoField" value="1240" />
           <input type="hidden" name="lpId" class="mktoField" value="2065" />
           <input type="hidden" name="subId" class="mktoField" value="30" />
           <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
@@ -417,5 +422,6 @@
     </div>
   </div>
 </section>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

* added google recaptcha to canonical.com forms

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: http://0.0.0.0:8002/services/contact-us and http://0.0.0.0:8002/partners/contact-us
4. See that the recaptcha form is there and the form submits
